### PR TITLE
Do not attempt to index 'nextn' if it’s a nil value

### DIFF
--- a/luavlna.lua
+++ b/luavlna.lua
@@ -280,7 +280,7 @@ local function prevent_single_letter (head)
         end
         end
         --]]
-        if test_fn(char, s) and nextn.id == glue_id then    -- only if we are at a one letter word
+        if test_fn(char, s) and nextn ~= nil and nextn.id == glue_id then    -- only if we are at a one letter word
           head = insert_penalty(head)
         end                                                                       
         space = false


### PR DESCRIPTION
Within a **tikzpicture** environment with label like `\coordinate [label=above:A] (A) at (60:1);` there is an error produced:
```
error: …/luavlna.lua:283: attempt to index local 'nextn' (a nil value)
```
This is fatal on Overleaf.